### PR TITLE
Fix parsing errors for public holiday

### DIFF
--- a/healthpointLocationsOpenNow.ts
+++ b/healthpointLocationsOpenNow.ts
@@ -139,8 +139,8 @@ async function getHealthpointLocation(body: string, url: string, branch: Branch)
     const holidayHoursTexts = holidayHoursEls.map((i, el) => $(el).text()).get();
     let exceptions: Record<string, string> = {}
     holidayHoursTexts.map(holidayHoursText => {
-      const [key, value] = holidayHoursText.split(': ')
-      exceptions[key] = value
+      const [key, ...value] = holidayHoursText.split(': ')
+      exceptions[key] = value.join(': ')
     })
 
     const noteEls = $('#section-hours2 p')

--- a/healthpointLocationsOpenNow.ts
+++ b/healthpointLocationsOpenNow.ts
@@ -139,7 +139,7 @@ async function getHealthpointLocation(body: string, url: string, branch: Branch)
     const holidayHoursTexts = holidayHoursEls.map((i, el) => $(el).text()).get();
     let exceptions: Record<string, string> = {}
     holidayHoursTexts.map(holidayHoursText => {
-      const [key, value] = holidayHoursText.split(':')
+      const [key, value] = holidayHoursText.split(': ')
       exceptions[key] = value
     })
 


### PR DESCRIPTION
Some public holiday entries for locations contain times. When we split strings with colon,
we need to take this into account so that information is not prematurely cut off.

Addresses issue in: https://github.com/CovidEngine/vaxxnz/issues/130